### PR TITLE
Eliminate my stupid mistake in the package.json NS version field...

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,12 +2,8 @@
   "name": "nativescript-ng2-magic",
   "nativescript": {
     "platforms": {
-      "ios": {
-        "version": "2.0.0"
-      },
-      "android": {
-        "version": "2.0.0"
-      }
+      "ios": "2.0.0",
+      "android":  "2.0.0"
     }
   },
   "version": "1.1.16",


### PR DESCRIPTION
Not sure why I thought the package.json file wanted it to be: nativescript->platforms->android(ios)->version = "version_text"

It should only be:
nativescript->platforms->android(ios) = "version_text"
